### PR TITLE
Create AMOLED-Builtin.js

### DIFF
--- a/Custom Themes/AMOLED-Builtin.js
+++ b/Custom Themes/AMOLED-Builtin.js
@@ -1,0 +1,1 @@
+document.body.classList.add("theme-amoled")


### PR DESCRIPTION
This uses the amoled class that already exists within the client (just does not have a public facing toggle)